### PR TITLE
Faster travis builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,7 @@
+conditions: v1
+
+if: type = pull_request OR tag IS present
+
 language: scala
 
 jdk:
@@ -28,9 +32,7 @@ cache:
     - $HOME/.sbt/boot/
 
 deploy:
-  on:
-    tags: true
-    branch: /^v[0-9]+(\.[0-9]+){2}$/
+  if: tag =~ /^v[0-9]+(\.[0-9]+){2}$/
   provider: script
   script: sbt -Dfile.encoding=UTF8 publish
   skip_cleanup: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,11 +9,12 @@ script:
 
 sudo: false
 
-# https://docs.travis-ci.com/user/languages/java/
-addons:
-  apt:
-    packages:
-      - oracle-java8-installer
+# https://docs.travis-ci.com/user/languages/java/#Updating-Oracle-JDK-8-to-a-recent-release
+# to use the latest Oracle JDK 8:
+#addons:
+#  apt:
+#    packages:
+#      - oracle-java8-installer
 
 before_cache:
   # Tricks to avoid unnecessary cache updates


### PR DESCRIPTION
* use pre-installed Oracle 8 JDK
* avoid [double builds](https://docs.travis-ci.com/user/pull-requests/#%E2%80%98Double-builds%E2%80%99-on-pull-requests) on PRs